### PR TITLE
Enhance UI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,7 +76,7 @@ export default function Home() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [inputLanguage, setInputLanguage] = useState("en");
   const [outputLanguage, setOutputLanguage] = useState("en");
-
+  
   // Get current translations based on selected language
   const t = translations[selectedLanguage as keyof typeof translations] || translations.en;
 
@@ -120,6 +120,7 @@ export default function Home() {
     if (file && file.type.startsWith('video/')) {
       setSelectedFile(file);
       setIsFileSelected(true);
+      setTranscriptionResult(""); // Clear previous transcription 
     } else if (file) {
       alert(t.pleaseSelectValidVideo);
     }
@@ -162,8 +163,14 @@ export default function Home() {
       console.error('Transcription error:', error);
       alert('Transcription failed. Please try again.');
     } finally {
-      setIsTranscribing(false);
+      resetToOriginalState();
     }
+  };
+
+  const resetToOriginalState = () => {
+    setSelectedFile(null);
+    setIsTranscribing(false);
+    setIsFileSelected(false);
   };
 
   return (


### PR DESCRIPTION
Previously -> Now

1. Video card stays "transcribing" after transcription is done -> Rerender video card to display the original state(so user could upload another video to transcribe)
2. Transcription result stays to contain previous transcription. When a new video is uploaded, prev result still present, but when we remove the selected video, result clear-> When a new video is uploaded, clear previous transcription result. (We might want to change the behaviour to stay until new transcription is done. TBD @jlu1211 what do you think?)

Next step: Going to add one click to copy in the result section(next to summary buttion)